### PR TITLE
Profile Persistence & User-Specific Data Fixes ✅

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -4,18 +4,18 @@
     <value>
       <entry key="app">
         <State>
-          <targetSelectedWithDropDown>
+          <runningDeviceTargetSelectedWithDropDown>
             <Target>
-              <type value="QUICK_BOOT_TARGET" />
+              <type value="RUNNING_DEVICE_TARGET" />
               <deviceKey>
                 <Key>
-                  <type value="VIRTUAL_DEVICE_PATH" />
-                  <value value="C:\Users\L27X16W21\.android\avd\Pixel_3a_API_35_extension_level_13_x86_64.avd" />
+                  <type value="SERIAL_NUMBER" />
+                  <value value="116343745M004269" />
                 </Key>
               </deviceKey>
             </Target>
-          </targetSelectedWithDropDown>
-          <timeTargetWasSelectedWithDropDown value="2025-02-26T08:18:14.513257300Z" />
+          </runningDeviceTargetSelectedWithDropDown>
+          <timeTargetWasSelectedWithDropDown value="2025-03-12T00:21:36.367402200Z" />
         </State>
       </entry>
     </value>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 android {
     namespace = "com.android.picmosaic"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         applicationId = "com.android.picmosaic"

--- a/app/src/main/java/com/android/picmosaic/DummyHomeActivity.kt
+++ b/app/src/main/java/com/android/picmosaic/DummyHomeActivity.kt
@@ -11,7 +11,7 @@ class DummyHomeActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.dummy_home_page)
-
+        checkLoginStatus()
         val settingsButton = findViewById<Button>(R.id.settingsButton)
 
         Toast.makeText(this, "Welcome to the Home Page!", Toast.LENGTH_SHORT).show()

--- a/app/src/main/java/com/android/picmosaic/DummyUserData.kt
+++ b/app/src/main/java/com/android/picmosaic/DummyUserData.kt
@@ -1,5 +1,7 @@
 package com.android.picmosaic
 
+import android.content.Context
+
 data class UserProfile(
     val email: String,
     val username: String,
@@ -29,11 +31,40 @@ object DummyUserData {
         return userCredentials[email] == password
     }
 
-    fun getUserProfile(email: String): UserProfile? {
-        return userProfiles[email]
+    fun getUserProfile(email: String, context: Context): UserProfile? {
+        val sharedPreferences = context.getSharedPreferences("PicMosaic", Context.MODE_PRIVATE)
+
+        return if (sharedPreferences.contains("username_$email")) {
+            UserProfile(
+                email = email,
+                username = sharedPreferences.getString("username_$email", "") ?: "",
+                firstName = sharedPreferences.getString("first_name_$email", "") ?: "",
+                lastName = sharedPreferences.getString("last_name_$email", "") ?: "",
+                phone = sharedPreferences.getString("phone_$email", "") ?: "",
+                address = sharedPreferences.getString("address_$email", "") ?: "",
+                city = sharedPreferences.getString("city_$email", "") ?: ""
+            )
+        } else {
+            userProfiles[email]  // Fallback to in-memory data if not found
+        }
     }
 
-    fun updateUserProfile(email: String, profile: UserProfile) {
-        userProfiles[email] = profile
+
+    fun updateUserProfile(email: String, profile: UserProfile, context: Context) {
+        userProfiles[email] = profile  // ✅ Updates in-memory data
+
+        val sharedPreferences = context.getSharedPreferences("PicMosaic", Context.MODE_PRIVATE)
+        val editor = sharedPreferences.edit()
+
+        with(editor) {
+            putString("username_$email", profile.username)
+            putString("first_name_$email", profile.firstName)
+            putString("last_name_$email", profile.lastName)
+            putString("phone_$email", profile.phone)
+            putString("address_$email", profile.address)
+            putString("city_$email", profile.city)
+            apply()  // ✅ Saves data permanently
+        }
     }
+
 }

--- a/app/src/main/java/com/android/picmosaic/LoginActivity.kt
+++ b/app/src/main/java/com/android/picmosaic/LoginActivity.kt
@@ -8,8 +8,9 @@ import android.widget.EditText
 import android.widget.TextView
 import android.widget.Toast
 import com.android.picmosaic.utils.isRegistered
-import com.android.picmosaic.utils.isValidEntry
+import com.android.picmosaic.utils.isNotValid
 import com.android.picmosaic.utils.toast
+import com.android.picmosaic.utils.txt
 
 class LoginActivity : Activity() {
     private lateinit var emailEditText: EditText
@@ -39,14 +40,12 @@ class LoginActivity : Activity() {
 
         // 🔹 Handle login button click
         loginButton.setOnClickListener {
-            val email = emailEditText.text.toString().trim()
-            val password = passwordEditText.text.toString().trim()
+            val email = emailEditText.txt()
+            val password = passwordEditText.txt()
 
-            if(emailEditText.isValidEntry()){
-                this.toast("Please enter email and password")
+            if(emailEditText.isNotValid() || passwordEditText.isNotValid()){
+                this.toast("Please fill out the forms completely")
                 return@setOnClickListener
-            }else if(passwordEditText.isValidEntry()){
-                this.toast("Please enter password")
             }
 
             if(isGoodtoLogin){
@@ -54,10 +53,10 @@ class LoginActivity : Activity() {
                 navigateToHome()
             }
 
-//            if (!DummyUserData.validateCredentials(email, password)) {
-//                Toast.makeText(this, "Invalid email or password", Toast.LENGTH_SHORT).show()
-//                return@setOnClickListener
-//            }
+            if (!DummyUserData.validateCredentials(email, password)) {
+                Toast.makeText(this, "Invalid email or password", Toast.LENGTH_SHORT).show()
+                return@setOnClickListener
+            }
 
             // 🔹 Save login state
             saveLoginData(email)

--- a/app/src/main/java/com/android/picmosaic/LogoutDialog.kt
+++ b/app/src/main/java/com/android/picmosaic/LogoutDialog.kt
@@ -27,20 +27,10 @@ class LogoutDialog(private val activity: Activity) : Dialog(activity) {
 
         //Click the "YES" button
         yesButton.setOnClickListener {
-            val sharedPref = activity.getSharedPreferences("PicMosaic", Context.MODE_PRIVATE)
-            val profileImagePath = sharedPref.getString("profile_image_path", null) // Keep image
-
-            // Clear everything except profile image
-            sharedPref.edit().clear().apply()
-
-            // Restore profile image path
-            sharedPref.edit().putString("profile_image_path", profileImagePath).apply()
-
-            val intent = Intent(context, LoginActivity::class.java)
-            intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-            context.startActivity(intent)
-            dismiss()
-            activity.finish()
+            (activity as? ProfileActivity)?.handleLogout() // Call the function from ProfileActivity
+            dismiss() // Close dialog
         }
+
+
     }
 }

--- a/app/src/main/java/com/android/picmosaic/RegisterActivity.kt
+++ b/app/src/main/java/com/android/picmosaic/RegisterActivity.kt
@@ -11,7 +11,7 @@ import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
 import com.android.picmosaic.utils.isRegistered
-import com.android.picmosaic.utils.isValidEntry
+import com.android.picmosaic.utils.isNotValid
 import com.android.picmosaic.utils.showError
 import com.android.picmosaic.utils.showSuccess
 import com.android.picmosaic.utils.txt
@@ -21,6 +21,7 @@ class RegisterActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.register)
+
         fun navigateToLogin() {
             startActivity(Intent(this, LoginActivity::class.java))
         }
@@ -29,7 +30,7 @@ class RegisterActivity : Activity() {
         val registerLastNameEditText = findViewById<EditText>(R.id.registerLastnameEditText)
         val registerAddressEditText = findViewById<EditText>(R.id.registerAddressEditText)
         val registerPhoneNumberEditText = findViewById<EditText>(R.id.registerPhoneNumberEditText)
-        val registerCityEditText = findViewById<EditText>(R.id.registerAddressEditText)
+        val registerCityEditText = findViewById<EditText>(R.id.registerCityText)
         val registerButton = findViewById<Button>(R.id.registerButton)
         val registerPageLoginButton = findViewById<Button>(R.id.registerPageLoginButton)
         val registerEmailEditText = findViewById<EditText>(R.id.registerEmailEditText)
@@ -43,7 +44,13 @@ class RegisterActivity : Activity() {
         }
 
         registerButton.setOnClickListener {
-            if(registerFirstNameEditText.isValidEntry() || registerLastNameEditText.isValidEntry() || registerAddressEditText.isValidEntry()||registerPhoneNumberEditText.isValidEntry() || registerCityEditText.isValidEntry() || registerEmailEditText.isValidEntry()||registerPasswordEditText.isValidEntry()){
+            if(registerFirstNameEditText.isNotValid()
+                || registerLastNameEditText.isNotValid()
+                || registerAddressEditText.isNotValid()
+                ||registerPhoneNumberEditText.isNotValid()
+                || registerCityEditText.isNotValid()
+                || registerEmailEditText.isNotValid()
+                ||registerPasswordEditText.isNotValid()){
                 showError("Please fill out the forms")
             }
             when {
@@ -78,6 +85,4 @@ class RegisterActivity : Activity() {
 
         }
     }
-
-    companion object
 }

--- a/app/src/main/java/com/android/picmosaic/utils/KExtension.kt
+++ b/app/src/main/java/com/android/picmosaic/utils/KExtension.kt
@@ -8,7 +8,7 @@ fun EditText.txt(): String{
     return this.text.toString()
 }
 
-fun EditText.isValidEntry(): Boolean{
+fun EditText.isNotValid(): Boolean{
     return this.text.toString().isNullOrEmpty()
 }
 


### PR DESCRIPTION
Profile information (name, phone, address, etc.) now persists after logout and login. Used SharedPreferences to store user data properly. 🔹 2. Fixed Profile Image Not Saving Per User
Each user now has their own profile picture stored separately. Image paths are now saved using the user’s email to prevent sharing across accounts. 🔹 3. Fixed Profile Page Not Switching After Save
After clicking Save, the app now automatically returns to the profile view. Used viewFlipper.showPrevious() to switch back.
🔹 4. Fixed Profile Picture Not Reloading After Save After updating the profile, the profile picture now refreshes immediately. Called loadSavedProfileImage() after saving changes. 🔹 5. Fixed Logout Keeping User Logged In
Now properly removes only the login session instead of clearing all data. Uses sharedPreferences.edit().remove("current_user_email").apply() to ensure proper logout.