### PR TITLE
Fixed Profile Image Discard Bug & Improved Profile Handling

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -3,20 +3,7 @@
   <component name="deploymentTargetDropDown">
     <value>
       <entry key="app">
-        <State>
-          <runningDeviceTargetSelectedWithDropDown>
-            <Target>
-              <type value="RUNNING_DEVICE_TARGET" />
-              <deviceKey>
-                <Key>
-                  <type value="SERIAL_NUMBER" />
-                  <value value="116343745M004269" />
-                </Key>
-              </deviceKey>
-            </Target>
-          </runningDeviceTargetSelectedWithDropDown>
-          <timeTargetWasSelectedWithDropDown value="2025-03-15T17:55:11.867586400Z" />
-        </State>
+        <State />
       </entry>
     </value>
   </component>


### PR DESCRIPTION
- Fixed issue where discarding a profile picture change still saved the new image.
- Ensured that discarded profile updates (including images) properly reload the last saved state.
- Improved navigation behavior after discarding edits—now correctly returns to profile view instead of home.
- Optimized profile data persistence for better user experience.